### PR TITLE
[HOTFIX][ZEPPELIN-3526] fix when no shiro.ini exists

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.server;
 
 import java.util.Collection;
 import org.apache.commons.lang.StringUtils;
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
@@ -102,19 +103,25 @@ public class ZeppelinServer extends Application {
 
   public ZeppelinServer() throws Exception {
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-    Collection<Realm> realms = ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils
-        .getSecurityManager()).getRealms();
-    if (realms.size() > 1) {
-      Boolean isIniRealmEnabled = false;
-      for (Object realm : realms) {
-        if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
-          isIniRealmEnabled = true;
-          break;
+    if (conf.getShiroPath().length() > 0) {
+      try {
+        Collection<Realm> realms = ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils
+            .getSecurityManager()).getRealms();
+        if (realms.size() > 1) {
+          Boolean isIniRealmEnabled = false;
+          for (Object realm : realms) {
+            if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
+              isIniRealmEnabled = true;
+              break;
+            }
+          }
+          if (isIniRealmEnabled) {
+            throw new Exception("IniRealm/password based auth mechanisms should be exclusive. "
+                + "Consider removing [users] block from shiro.ini");
+          }
         }
-      }
-      if (isIniRealmEnabled) {
-        throw new Exception("IniRealm/password based auth mechanisms should be exclusive. "
-            + "Consider removing [users] block from shiro.ini");
+      } catch (UnavailableSecurityManagerException e) {
+        LOG.error("Failed to initialise shiro configuraion", e);
       }
     }
 


### PR DESCRIPTION
This is a side effect of ZEPPELIN-3526, occurs when there's no shiro.ini in the classpath.

[Hot Fix]

* CI should be green

* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

Author: Prabhjyot Singh <prabhjyotsingh@gmail.com>

Closes #3011 from prabhjyotsingh/hotfix/ZEPPELIN-3526 and squashes the following commits:

ac6565cd3 [Prabhjyot Singh] fix ZEPPELIN-3526 when no shiro.ini exists

Change-Id: I5016e293eeec17e44be29dbf7f2668ec542a8dfa

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
